### PR TITLE
fix: replace nvidia-smi package with cuda-drivers

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -40,7 +40,7 @@ stages:
           - nvidia-vaapi-driver
           - nvidia-settings
           - nvidia-persistenced
-          - nvidia-smi
+          - cuda-drivers
           - libnvidia-cfg1
           - libnvidia-glcore
           - libnvidia-glvkspirv


### PR DESCRIPTION
- replace `nvidia-smi` package with `cuda-drivers`

```bash
nvidia-smi
```
```
Mon Nov 11 10:59:26 2024       
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 565.57.01              Driver Version: 565.57.01      CUDA Version: 12.7     |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA T1200 Laptop GPU        Off |   00000000:01:00.0 Off |                  N/A |
| N/A   49C    P8              2W /   40W |       3MiB /   4096MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A      4072      G   /usr/bin/gnome-shell                            1MiB |
+-----------------------------------------------------------------------------------------+
```

https://forums.developer.nvidia.com/t/nvidia-smi-missing-for-565-drivers-debian-12-packages/311702