### PR TITLE
fix: remove nvidia repo during cleanup

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -90,6 +90,7 @@ stages:
     - apt remove -y zutty gnome-shell-extension-prefs
     - SUDO_FORCE_REMOVE=yes apt purge -y sudo
     - lpkg --lock
+    - rm /etc/apt/sources.list.d/nvidia-drivers.list 
 
   - name: fsguard
     type: fsguard


### PR DESCRIPTION
Alternative fix for vso updating on the nvidia-exp image.  This removes the nvidia repo after building the image so that containers that use the hosts apt config will not try to pull from nvidia without the key.  The nvidia drivers are updated through the image building mechanism and do not function outside of that context and will/cannot be updated via apt.


closes https://github.com/Vanilla-OS/vso-image/issues/44