### PR TITLE
feat:[#7] move nvidia components to external vib module

### DIFF
--- a/modules/50-nvidia-driver-install.yml
+++ b/modules/50-nvidia-driver-install.yml
@@ -1,0 +1,30 @@
+name: nvidia-official-driver
+type: shell
+commands:
+- apt-mark hold nvidia-kernel-open nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-persistenced nvidia-smi libnvidia-cfg1 libnvidia-glcore libnvidia-glvkspirv libnvidia-gpucomp libnvidia-fbc1 nvidia-container-toolkit
+
+modules:
+- name: install-nvidia
+  type: apt
+  source:
+    packages:
+    - nvidia-kernel-open
+    - nvidia-driver
+    - nvidia-vaapi-driver
+    - nvidia-settings
+    - nvidia-persistenced
+    - cuda-drivers
+    - libnvidia-cfg1
+    - libnvidia-glcore
+    - libnvidia-glvkspirv
+    - libnvidia-gpucomp
+    - libnvidia-fbc1
+    - nvidia-container-toolkit
+  modules:
+    - name: nvidia-official-repo
+      type: shell
+      commands:
+      - curl -fSsL https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-drivers.gpg
+      - echo 'deb [signed-by=/usr/share/keyrings/nvidia-drivers.gpg] https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/ /' > /etc/apt/sources.list.d/nvidia-drivers.list
+      - apt-get update
+

--- a/modules/51-nvidia-systemd-units.yml
+++ b/modules/51-nvidia-systemd-units.yml
@@ -1,0 +1,8 @@
+name: nvidia-sysd-units
+type: shell
+commands:
+- mkdir -p /etc/systemd/system/systemd-suspend.service.wants
+- mkdir -p /etc/systemd/system/systemd-hibernate.service.wants
+- ln -s /usr/lib/systemd/system/nvidia-suspend.service /etc/systemd/system/systemd-suspend.service.wants/nvidia-suspend.service
+- ln -s /usr/lib/systemd/system/nvidia-hibernate.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-hibernate.service
+- ln -s /usr/lib/systemd/system/nvidia-resume.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-resume.service

--- a/recipe.yml
+++ b/recipe.yml
@@ -19,43 +19,11 @@ stages:
     - lpkg --unlock
     - apt-get update
 
-  - name: nvidia-official-repo
-    type: shell
-    commands:
-    - curl -fSsL https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-drivers.gpg
-    - echo 'deb [signed-by=/usr/share/keyrings/nvidia-drivers.gpg] https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/ /' > /etc/apt/sources.list.d/nvidia-drivers.list
-    - apt-get update
-
-  - name: nvidia-official-driver
-    type: shell
-    commands:
-    - apt-mark hold nvidia-kernel-open nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-persistenced nvidia-smi libnvidia-cfg1 libnvidia-glcore libnvidia-glvkspirv libnvidia-gpucomp libnvidia-fbc1 nvidia-container-toolkit
-    modules:
-      - name: install-nvidia
-        type: apt
-        source:
-          packages:
-          - nvidia-kernel-open
-          - nvidia-driver
-          - nvidia-vaapi-driver
-          - nvidia-settings
-          - nvidia-persistenced
-          - cuda-drivers
-          - libnvidia-cfg1
-          - libnvidia-glcore
-          - libnvidia-glvkspirv
-          - libnvidia-gpucomp
-          - libnvidia-fbc1
-          - nvidia-container-toolkit
-
-  - name: nvidia-sysd-units
-    type: shell
-    commands:
-    - mkdir -p /etc/systemd/system/systemd-suspend.service.wants
-    - mkdir -p /etc/systemd/system/systemd-hibernate.service.wants
-    - ln -s /usr/lib/systemd/system/nvidia-suspend.service /etc/systemd/system/systemd-suspend.service.wants/nvidia-suspend.service
-    - ln -s /usr/lib/systemd/system/nvidia-hibernate.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-hibernate.service
-    - ln -s /usr/lib/systemd/system/nvidia-resume.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-resume.service
+  - name: packages-modules
+    type: includes
+    includes:
+      - modules/50-nvidia-driver-install.yml
+      - modules/51-nvidia-systemd-units.yml
 
   - name: extra-utilities
     type: apt


### PR DESCRIPTION
move the nvidia install components to a separate yaml module.  this allows people to more easily pull those vib components to use with custom images

closes #7 